### PR TITLE
chore: add agenty-flowcharting-panel plugin to eks

### DIFF
--- a/grafana-aks/main.tf
+++ b/grafana-aks/main.tf
@@ -109,4 +109,5 @@ module "grafana" {
   root_domain             = var.root_domain
   ingress_enabled         = var.ingress_enabled
   ingress_hostnames       = var.ingress_hostnames
+  plugins                 = var.plugins
 }

--- a/grafana-aks/variables.tf
+++ b/grafana-aks/variables.tf
@@ -68,3 +68,9 @@ variable "cluster_name" {
 variable "cluster_outbound_ips" {
   type = list(string)
 }
+
+variable "plugins" {
+  description = "Plugins in addition to the default ones"
+  type        = list(string)
+  default     = []
+}

--- a/grafana-eks/main.tf
+++ b/grafana-eks/main.tf
@@ -14,6 +14,7 @@ locals {
   bucket_name   = module.s3_bucket.s3_bucket_id
   role_name     = local.bucket_name
   provider_url  = replace(var.oidc_provider_issuer_url, "https://", "")
+  plugins       = ["agenty-flowcharting-panel"]
 }
 
 data "aws_region" "grafana" {}
@@ -147,4 +148,5 @@ module "grafana" {
   root_domain             = var.root_domain
   ingress_enabled         = var.ingress_enabled
   ingress_hostnames       = var.ingress_hostnames
+  plugins                 = local.plugins
 }

--- a/grafana-eks/main.tf
+++ b/grafana-eks/main.tf
@@ -14,7 +14,6 @@ locals {
   bucket_name   = module.s3_bucket.s3_bucket_id
   role_name     = local.bucket_name
   provider_url  = replace(var.oidc_provider_issuer_url, "https://", "")
-  plugins       = ["agenty-flowcharting-panel"]
 }
 
 data "aws_region" "grafana" {}
@@ -148,5 +147,5 @@ module "grafana" {
   root_domain             = var.root_domain
   ingress_enabled         = var.ingress_enabled
   ingress_hostnames       = var.ingress_hostnames
-  plugins                 = local.plugins
+  plugins                 = var.plugins
 }

--- a/grafana-eks/variables.tf
+++ b/grafana-eks/variables.tf
@@ -142,3 +142,9 @@ variable "database_auto_minor_version_upgrade" {
 variable "chart_values" {
   default = {}
 }
+
+variable "plugins" {
+  description = "Plugins in addition to the default ones"
+  type        = list(string)
+  default     = []
+}

--- a/grafana/main.tf
+++ b/grafana/main.tf
@@ -76,7 +76,7 @@ locals {
       } : {}
     }
 
-    plugins = []
+    plugins = var.plugins
 
     datasources = {
       "datasources.yaml" = {

--- a/grafana/variables.tf
+++ b/grafana/variables.tf
@@ -122,3 +122,9 @@ variable "eks_iam_role_arn" {
   type        = string
   default     = null
 }
+
+variable "plugins" {
+  description = "Plugins in addition to the default ones"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Made it possible to add it for both, but only add it for eks (which the request was for).
Test with https://github.com/nuuday/terraform-managed-k8s/pull/129