### PR TITLE
feat(aks): Bumped AzureRM provider from ~>2.68 to ~>3.27

### DIFF
--- a/grafana-aks/main.tf
+++ b/grafana-aks/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.68"
+      version = "~> 3.27"
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Resources offered by the AzureRM provider has changed from version 2 to 3.
